### PR TITLE
Remove redundant header fragment

### DIFF
--- a/manifests/server/command.pp
+++ b/manifests/server/command.pp
@@ -42,18 +42,11 @@ define remctl::server::command (
             warn    => true
         }
 
-        concat::fragment { "${command}_puppet_header":
-            ensure          => present,
-            target          => $cmdfile,
-            order           => '01',
-            content         => "# This file is being maintained by Puppet.\n# DO NOT EDIT\n"
-        }
     }
 
     concat::fragment { "${command}_${subcommand}":
         ensure          => $ensure,
         target          => $cmdfile,
-        order           => '02',
         content         => template('remctl/server/command.erb'),
     }
 }

--- a/templates/server/aclfile.erb
+++ b/templates/server/aclfile.erb
@@ -8,7 +8,7 @@ If there is any ambiguity, prepend the method.
 Each entry is checked in order, and access is granted as soon as an entry matches.
 If no entry matches, access is denied.
 -%>
-
+# This file is managed by Puppet. DO NOT EDIT
 <% @acls.each do |acl| -%>
 <%= acl %>
 <% end -%>


### PR DESCRIPTION
Concat already adds its own header with _warn => true_, so the additional fragment is redundant.
The aclfile.erb did therefor not include any header, so adding one here as well.